### PR TITLE
feature/project-page

### DIFF
--- a/app/post/page.tsx
+++ b/app/post/page.tsx
@@ -1,3 +1,4 @@
+import { Metadata } from "next";
 import { SanityDocument } from "next-sanity";
 import { draftMode } from "next/headers";
 
@@ -5,7 +6,7 @@ import Posts from "@/components/post/posts";
 import { PostsPreview } from "@/components/post/post-preview";
 import { loadQuery } from "@/sanity/lib/store";
 import { POSTS_QUERY } from "@/sanity/lib/queries";
-import { Metadata } from "next";
+import Container from "@/components/layout/container";
 
 export const metadata: Metadata = {
   title: "Posts - Prajna",
@@ -24,6 +25,13 @@ export default async function PostPage() {
   return draftMode().isEnabled ? (
     <PostsPreview initial={initial} />
   ) : (
-    <Posts posts={initial.data} />
+    <Container>
+      <section className="space-y-2">
+        <h1 className="scroll-m-20 text-xl font-semibold tracking-tight">
+          Posts
+        </h1>
+        <Posts posts={initial.data} />
+      </section>
+    </Container>
   );
 }

--- a/app/project/page.tsx
+++ b/app/project/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 export default function ProjectPage() {
   return (
     <Container>
-      <section>
+      <section className="space-y-2">
         <h1 className="scroll-m-20 text-xl font-semibold tracking-tight">
           Projects
         </h1>

--- a/app/project/page.tsx
+++ b/app/project/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import Container from "@/components/layout/container";
+import { ProjectsList } from "@/components/project/list";
+
+export const metadata: Metadata = {
+  title: "Projects - Prajna",
+  description: "Projects I've worked on",
+};
+
+export default function ProjectPage() {
+  return (
+    <Container>
+      <section>
+        <h1 className="scroll-m-20 text-xl font-semibold tracking-tight">
+          Projects
+        </h1>
+        <ProjectsList />
+      </section>
+    </Container>
+  );
+}

--- a/components/post/card.tsx
+++ b/components/post/card.tsx
@@ -14,7 +14,10 @@ export const PostCard = ({ post }: { post: SanityDocument }) => {
   } = post;
 
   return (
-    <article className="container mx-auto grid grid-cols-1 divide-y divide-blue-100 bg-zinc-100 hover:bg-zinc-200/70 rounded-xl p-4 space-y-2">
+    <article
+      key={_id}
+      className="container mx-auto grid grid-cols-1 divide-y divide-blue-100 bg-zinc-100 hover:bg-zinc-200/70 rounded-xl p-4 space-y-2"
+    >
       <Link href={`/post/${slug.current}`} key={_id}>
         <div className="flex items-center justify-between space-x-2">
           <p className="text-md text-zinc-800">{title}</p>

--- a/components/post/posts.tsx
+++ b/components/post/posts.tsx
@@ -5,12 +5,12 @@ import { PostCard } from "./card";
 
 export default function Posts({ posts }: { posts: SanityDocument[] }) {
   return (
-    <Container>
+    <>
       {posts?.length > 0 ? (
         posts.map((post) => <PostCard key={post._id} post={post} />)
       ) : (
         <div className="py-2 text-red-500">No posts found.</div>
       )}
-    </Container>
+    </>
   );
 }

--- a/components/project/card.tsx
+++ b/components/project/card.tsx
@@ -15,7 +15,7 @@ export const ProjectCard = ({ project }: { project: SanityDocument }) => {
         <p className="text-md text-zinc-800">{name}</p>
       </div>
 
-      <p className="text-zinc-500 text-balance text-sm my-2">{description}</p>
+      <p className="text-zinc-500 text-pretty text-sm my-2">{description}</p>
 
       <div className="flex items-center space-x-1">
         {githubLink && (

--- a/components/project/card.tsx
+++ b/components/project/card.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { SanityDocument } from "next-sanity";
+import Link from "next/link";
+
+export const ProjectCard = ({ project }: { project: SanityDocument }) => {
+  const { _id, name, description, link, githubLink } = project;
+
+  return (
+    <article
+      key={_id}
+      className="container mx-auto grid grid-cols-1 bg-zinc-50/40 border hover:border-zinc-300 border-zinc-200 rounded-lg p-3 space-y-2 shadow-sm"
+    >
+      <div className="flex items-center justify-between">
+        <p className="text-md text-zinc-800">{name}</p>
+      </div>
+
+      <p className="text-zinc-500 text-balance text-sm my-2">{description}</p>
+
+      <div className="flex items-center space-x-1">
+        {githubLink && (
+          <Link
+            href={githubLink}
+            target="_blank"
+            className="inline-flex items-center space-x-1 bg-zinc-100 border border-zinc-300 text-zinc-500 rounded-md px-3 py-1 text-xs font-medium cursor-pointer hover:bg-zinc-200/70 animate-hover transition-all duration-200 ease-in-out "
+          >
+            <GitHubIcon />
+            <span>GitHub</span>
+          </Link>
+        )}
+
+        {link && (
+          <Link
+            href={link}
+            target="_blank"
+            className="inline-flex items-center space-x-1 bg-zinc-100 border border-zinc-300 text-zinc-500 rounded-md px-3 py-1 text-xs font-medium cursor-pointer hover:bg-zinc-200/70 animate-hover transition-all duration-200 ease-in-out "
+          >
+            <ExternalLinkIcon />
+            <span>Go Live</span>
+          </Link>
+        )}
+      </div>
+    </article>
+  );
+};
+
+const GitHubIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className="icon icon-tabler icon-tabler-brand-github"
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    strokeWidth="2"
+    stroke="currentColor"
+    fill="none"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path d="M9 19c-4.3 1.4 -4.3 -2.5 -6 -3m12 5v-3.5c0 -1 .1 -1.4 -.5 -2c2.8 -.3 5.5 -1.4 5.5 -6a4.6 4.6 0 0 0 -1.3 -3.2a4.2 4.2 0 0 0 -.1 -3.2s-1.1 -.3 -3.5 1.3a12.3 12.3 0 0 0 -6.2 0c-2.4 -1.6 -3.5 -1.3 -3.5 -1.3a4.2 4.2 0 0 0 -.1 3.2a4.6 4.6 0 0 0 -1.3 3.2c0 4.6 2.7 5.7 5.5 6c-.6 .6 -.6 1.2 -.5 2v3.5" />
+  </svg>
+);
+
+const ExternalLinkIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className="icon icon-tabler icon-tabler-external-link"
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    strokeWidth="2"
+    stroke="currentColor"
+    fill="none"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path d="M12 6h-6a2 2 0 0 0 -2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-6" />
+    <path d="M11 13l9 -9" />
+    <path d="M15 4h5v5" />
+  </svg>
+);

--- a/components/project/list.tsx
+++ b/components/project/list.tsx
@@ -1,0 +1,32 @@
+import { draftMode } from "next/headers";
+import { SanityDocument } from "next-sanity";
+
+import { loadQuery } from "@/sanity/lib/store";
+import { PROJECTS_QUERY } from "@/sanity/lib/queries";
+import { ProjectCard } from "./card";
+
+export const ProjectsList = async () => {
+  const projects = await loadQuery<SanityDocument[]>(
+    PROJECTS_QUERY,
+    {},
+    {
+      perspective: draftMode().isEnabled ? "previewDrafts" : "published",
+    }
+  );
+
+  return draftMode().isEnabled ? (
+    <></>
+  ) : (
+    <article className="grid grid-cols-1 md:grid-cols-2 gap-4 my-6">
+      {projects.data.length > 0 ? (
+        projects.data.map((project) => (
+          <ProjectCard key={project._id} project={project} />
+        ))
+      ) : (
+        <div className="py-2 text-red-500">
+          No posts found for this category.
+        </div>
+      )}
+    </article>
+  );
+};

--- a/sanity/lib/queries.ts
+++ b/sanity/lib/queries.ts
@@ -32,3 +32,10 @@ export const CATEGORY_QUERY = groq`*[_type == "category" && slug.current ==   $s
     "estimatedReadingTime": round(length(pt::text(body)) / 5 / 180)
   }
 }`;
+
+export const PROJECTS_QUERY = groq`*[_type == "project"]{
+  name,
+  description,
+  link,
+  githubLink,
+}`;

--- a/sanity/schema.ts
+++ b/sanity/schema.ts
@@ -1,9 +1,10 @@
-import { type SchemaTypeDefinition } from 'sanity'
+import { type SchemaTypeDefinition } from "sanity";
 
-import blockContent from './schemas/blockContent'
-import category from './schemas/category'
-import post from './schemas/post'
+import blockContent from "./schemas/blockContent";
+import category from "./schemas/category";
+import project from "./schemas/project";
+import post from "./schemas/post";
 
 export const schema: { types: SchemaTypeDefinition[] } = {
-  types: [post, category, blockContent],
-}
+  types: [post, project, category, blockContent],
+};

--- a/sanity/schemas/project.ts
+++ b/sanity/schemas/project.ts
@@ -1,0 +1,29 @@
+import { defineField, defineType } from "sanity";
+
+export default defineType({
+  name: "project",
+  title: "Project",
+  type: "document",
+  fields: [
+    defineField({
+      name: "name",
+      title: "Project Name",
+      type: "string",
+    }),
+    defineField({
+      name: "description",
+      title: "Description",
+      type: "text",
+    }),
+    defineField({
+      name: "link",
+      title: "Link",
+      type: "url",
+    }),
+    defineField({
+      name: "githubLink",
+      title: "Github Link",
+      type: "url",
+    }),
+  ],
+});


### PR DESCRIPTION
This PR addresses the need for displaying projects on the Project page. The following changes have been made:

* Created a new Sanity schema named project. This schema includes fields for image, name, labels, description, and GitHub URL or Live demo information.

* Added a new query in @/sanity/lib/queries.ts that fetches all projects from the Sanity CMS.

* Developed new components for displaying the project list and individual project cards. These components have been integrated into the Project page.

* Implemented a function to fetch projects from the Sanity CMS and pass them to the new components.

These changes allow us to display a list of projects on the Project page, each with relevant details and links.